### PR TITLE
chore: Remove stdsimd feature.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@
     naked_functions,
     asm_const,
     negative_impls,
-    stdsimd,
     riscv_ext_intrinsics
 )]
 


### PR DESCRIPTION
This feature has been removed: https://github.com/tkaitchuck/aHash/pull/183.